### PR TITLE
Issue #2: Return OK messages for what is documented in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *.iml
 .idea
 *.swp
+*.log

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import javax.inject.Inject
+
+import play.api.http.{ContentTypes, MimeTypes}
+import play.api.mvc._
+
+class Main @Inject()(components: ControllerComponents)
+    extends AbstractController(components) {
+
+  def aChannel() = Action { request: Request[AnyContent] =>
+    if (request.acceptedTypes.exists(_.toString() == MimeTypes.EVENT_STREAM)) {
+      Ok("").as(ContentTypes.EVENT_STREAM)
+    } else Ok("").as(ContentTypes.withCharset(Main.TsvMimeType))
+  }
+
+}
+
+object Main {
+
+  val TsvMimeType = "text/tab-separated-values"
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -1,0 +1,1 @@
+GET         /a-channel        @controllers.Main.aChannel

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.14-RC2
+sbt.version=0.13.13


### PR DESCRIPTION
Closes Issue #2: Return OK messages for what is documented in README.md.

<details>

```
$ sbt docker:publishLocal
$ docker run -p 9000:9000 scalawilliam/eventsource-hub:67c0efd1834e34e8bed931f54a54676fb3aef5fd-SNAPSHOT
$ curl -H 'Accept: text/event-stream' -i http://localhost:9000/a-channel
HTTP/1.1 200 OK
Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'self'
X-Permitted-Cross-Domain-Policies: master-only
Date: Wed, 05 Apr 2017 01:40:41 GMT
Content-Type: text/event-stream; charset=utf-8
Content-Length: 0
$ curl -i http://localhost:9000/a-channel
HTTP/1.1 200 OK
Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'self'
X-Permitted-Cross-Domain-Policies: master-only
Date: Wed, 05 Apr 2017 01:40:56 GMT
Content-Type: text/tab-separated-values; charset=utf-8
Content-Length: 0
```

</details>